### PR TITLE
Do not allow URLs to leak outside of the app scope

### DIFF
--- a/index.html
+++ b/index.html
@@ -391,7 +391,7 @@
                     </ol>
                   </li>
                   <li>
-                    [=navigate=] |application context| to |launch
+                    [=Navigate=] |application context| to |launch
                     params|.{{LaunchParams/targetURL}} passing |POST resource|.
                   </li>
                   <li>Return |application context|.
@@ -536,7 +536,7 @@
       </h2>
       <p>
         Implementations should take care when [=launching a web application with
-        handling=] that launches where [=manifest/client_mode=] is
+        handling=] for launches where [=manifest/client_mode=] is
         [=client mode/focus-existing=]. These launches MUST NOT leak URLs
         outside of the [=manifest/navigation scope=]. This applies in both
         directions given a [=Document/processed manifest=] |manifest|:
@@ -550,7 +550,7 @@
             context=] with a <a data-cite="html#nav-current-history-entry">
             current session history entry</a>
             <a data-cite="html#she-url">URL</a> that is not [=manifest/within
-            scope=] of |manifest|:
+            scope=] of |manifest|.
           </li>
         </ol>
       </p>

--- a/index.html
+++ b/index.html
@@ -358,10 +358,15 @@
               <dd>
                 <ol class="algorithm">
                   <li>If there is no [=application context=] that has |manifest|
-                      [=applied=], return the result of running the steps to
-                      [=create a new application context=] passing |manifest|,
-                      |launch params|.{{LaunchParams/targetURL}} and |POST
-                      resource|.
+                      [=applied=]:
+                    <ol>
+                      <li>
+                        Return the result of running the steps to [=create a new
+                        application context=] passing |manifest|,
+                        |launch params|.{{LaunchParams/targetURL}} and |POST
+                        resource|.
+                      </li>
+                    </ol>
                   </li>
                   <li>Let |application context| be an [=application context=]
                       that has |manifest| [=applied=], the user agent selects
@@ -371,12 +376,23 @@
                         one that was most recently in focus.
                       </p>
                   </li>
-                  <li>Bring |application context|'s viewport into focus.
+                  <li>
+                    If |client mode| is [=client mode/focus-existing=] and
+                    |application context|'s
+                    <a data-cite="html#nav-current-history-entry">current
+                    session history entry</a>'s
+                    <a data-cite="html#she-url">URL</a> is [=manifest/within
+                    scope=] of |manifest|:
+                    <ol>
+                      <li>Bring |application context|'s viewport into focus.
+                      </li>
+                      <li>Return |application context|.
+                      </li>
+                    </ol>
                   </li>
-                  <li>If |client mode| is [=client mode/navigate-existing=],
-                      [=navigate=] |application context| to |launch
-                      params|.{{LaunchParams/targetURL}} passing |POST
-                      resource|.
+                  <li>
+                    [=navigate=] |application context| to |launch
+                    params|.{{LaunchParams/targetURL}} passing |POST resource|.
                   </li>
                   <li>Return |application context|.
                   </li>
@@ -512,6 +528,33 @@
       </h2>
       <p>
         This specification has no known accessibility considerations.
+      </p>
+    </section>
+    <section id="priv-sec">
+      <h2>
+        Privacy and Security Considerations
+      </h2>
+      <p>
+        Implementations should take care when [=launching a web application with
+        handling=] that launches where [=manifest/client_mode=] is
+        [=client mode/focus-existing=]. These launches MUST NOT leak URLs
+        outside of the [=manifest/navigation scope=]. This applies in both
+        directions given a [=Document/processed manifest=] |manifest|:
+        <ol>
+          <li>
+            Web application launches MUST NOT use a {{LaunchParams/targetURL}}
+            that is not [=manifest/within scope=] of |manifest|.
+          </li>
+          <li>
+            {{LaunchParams}} MUST NOT be enqueued in an [=application
+            context=] with a <a data-cite="html#nav-current-history-entry">
+            current session history entry</a>
+            <a data-cite="html#she-url">URL</a> that is not [=manifest/within
+            scope=] of |manifest|:
+          </li>
+        </ol>
+      </p>
+      <p>
       </p>
     </section>
     <section id="conformance"></section>

--- a/index.html
+++ b/index.html
@@ -540,7 +540,7 @@
         [=client mode/focus-existing=]. These launches MUST NOT leak URLs
         outside of the [=manifest/navigation scope=]. This applies in both
         directions given a [=Document/processed manifest=] |manifest|:
-        <ol>
+        <ul>
           <li>
             Web application launches MUST NOT use a {{LaunchParams/targetURL}}
             that is not [=manifest/within scope=] of |manifest|.
@@ -552,7 +552,7 @@
             <a data-cite="html#she-url">URL</a> that is not [=manifest/within
             scope=] of |manifest|.
           </li>
-        </ol>
+        </ul>
       </p>
       <p>
       </p>


### PR DESCRIPTION
This updates the focus-existing behaviour to check first whether the |application context| is even in the app scope before not navigating it. This can happen if the user navigates outside of the app scope in an existing app window prior to launching the web app again while `focus-existing` is active.